### PR TITLE
ns: set SalesForce field value to null when column has a null value. Per...

### DIFF
--- a/lib/salesforce/column.rb
+++ b/lib/salesforce/column.rb
@@ -57,6 +57,8 @@ module Salesforce
           'FALSE'
         when Time;
           obj.xmlschema
+        when NilClass;
+          '#N/A'
         else
           "#{obj.to_s}"
       end

--- a/test/salesforce/column_test.rb
+++ b/test/salesforce/column_test.rb
@@ -59,7 +59,7 @@ class Salesforce::ColumnTest < ActiveSupport::TestCase
     assert_equal "string", Salesforce::Column.to_csv_value('string') 
     assert_equal "TRUE", Salesforce::Column.to_csv_value(true) 
     assert_equal "FALSE", Salesforce::Column.to_csv_value(false) 
-    assert_equal "", Salesforce::Column.to_csv_value(nil) 
+    assert_equal '#N/A', Salesforce::Column.to_csv_value(nil) 
     assert_equal "2012-01-02", Salesforce::Column.to_csv_value(Date.parse('2012-01-02')) 
     assert_equal "2012-01-02T18:40:00-08:00", Salesforce::Column.to_csv_value(Time.zone.parse('2012-01-02 06:40PM')) 
     assert_equal "1", Salesforce::Column.to_csv_value(1) 


### PR DESCRIPTION
... SalesForce documentation: 'Empty field values are ignored when you update records. To set a field value to null, use a field value of #N/A'
