### PR TITLE
Support My Domain [#153618694]

### DIFF
--- a/lib/salesforce/authentication.rb
+++ b/lib/salesforce/authentication.rb
@@ -12,7 +12,12 @@ module Salesforce
       result = Connection.login    
       Config.instance.soap_endpoint_url result[:server_url]
       Config.instance.session_id        result[:session_id]
-      Config.instance.server_instance   URI.parse(result[:server_url]).host[/(na|cs)\d+/]
+
+      host = URI.parse(result[:server_url]).host
+      host_match = host.match(/(?<instance>[a-z0-9\-]+)\.(?<domain>(?:my\.)?salesforce\.com)/)
+
+      Config.instance.server_instance   host_match[:instance]
+      Config.instance.server_domain     host_match[:domain]
       Config.instance.user_id           result[:user_id]
       Config.session_id
     end

--- a/lib/salesforce/config.rb
+++ b/lib/salesforce/config.rb
@@ -6,11 +6,11 @@ module Salesforce
     include Blockenspiel::DSL
     include Blockenspiel::DSLSetupMethods
 
-    dsl_attr_accessor :session_id, :server_instance, :user_id, :soap_endpoint_url
+    dsl_attr_accessor :session_id, :server_instance, :server_domain, :user_id, :soap_endpoint_url
 
     [
       :username, :password, :api_version, :use_sandbox?, :use_full_length_ids?,
-      :login_url, :session_id, :server_instance, :soap_endpoint_url, :soap_enterprise_namespace,
+      :login_url, :session_id, :server_instance, :server_domain, :soap_endpoint_url, :soap_enterprise_namespace,
       :user_id, :server_url, :server_host, :async_url, :configured?, :on_login_failure ].each do |method_name|
       eval <<-RUBY
       def self.#{method_name}
@@ -88,15 +88,15 @@ module Salesforce
     end
 
     def server_url
-      "https://#{server_instance}.salesforce.com/services/data/v#{api_version}"
+      "https://#{server_instance}.#{server_domain}/services/data/v#{api_version}"
     end
 
     def server_host
-      "https://#{server_instance}.salesforce.com"
+      "https://#{server_instance}.#{server_domain}"
     end
 
     def async_url
-      "https://#{server_instance}.salesforce.com/services/async/#{api_version}"
+      "https://#{server_instance}.#{server_domain}/services/async/#{api_version}"
     end
 
     def login_url

--- a/test/salesforce/authentication_test.rb
+++ b/test/salesforce/authentication_test.rb
@@ -46,6 +46,24 @@ class Salesforce::AuthenticationTest < ActiveSupport::TestCase
     assert_equal "https://cs99.salesforce.com/services/Soap/c/22.0/00DQ00000001LRX", Salesforce::Config.soap_endpoint_url
     assert_equal "session_id", Salesforce::Config.session_id
     assert_equal "cs99", Salesforce::Config.server_instance
+    assert_equal "salesforce.com", Salesforce::Config.server_domain
+    assert_equal "user_id", Salesforce::Config.user_id
+  end
+
+  def test_generate_new_session_id__calls_connection_login__my_domain
+    result = {
+      :session_id => "session_id",
+      :server_url => "https://awesome-2000.my.salesforce.com/services/Soap/c/22.0/00DQ00000001LRX",
+      :user_id    => "user_id"
+    }
+
+    Salesforce.connection.expects(:login).returns(result)
+
+    assert_equal "session_id", Salesforce::Authentication.generate_new_session_id
+    assert_equal "https://awesome-2000.my.salesforce.com/services/Soap/c/22.0/00DQ00000001LRX", Salesforce::Config.soap_endpoint_url
+    assert_equal "session_id", Salesforce::Config.session_id
+    assert_equal "awesome-2000", Salesforce::Config.server_instance
+    assert_equal "my.salesforce.com", Salesforce::Config.server_domain
     assert_equal "user_id", Salesforce::Config.user_id
   end
   

--- a/test/salesforce/config_test.rb
+++ b/test/salesforce/config_test.rb
@@ -112,6 +112,9 @@ class Salesforce::ConfigTest < ActiveSupport::TestCase
     
     config.server_instance "na99"
     assert_equal "na99", Salesforce::Config.server_instance
+
+    config.server_domain "something.salesforce.com"
+    assert_equal "something.salesforce.com", Salesforce::Config.server_domain
     
     config.user_id "user_id"
     assert_equal "user_id", Salesforce::Config.user_id
@@ -121,9 +124,10 @@ class Salesforce::ConfigTest < ActiveSupport::TestCase
   def test_server_url__and_server_host
     config = Salesforce::Config.instance
     config.server_instance "sa2"
+    config.server_domain "something.salesforce.com"
     config.api_version 99
-    assert_equal "https://sa2.salesforce.com/services/data/v99.0", Salesforce::Config.server_url
-    assert_equal "https://sa2.salesforce.com", Salesforce::Config.server_host
+    assert_equal "https://sa2.something.salesforce.com/services/data/v99.0", Salesforce::Config.server_url
+    assert_equal "https://sa2.something.salesforce.com", Salesforce::Config.server_host
   end
   
   def test_configured

--- a/test/salesforce/connection/async_test.rb
+++ b/test/salesforce/connection/async_test.rb
@@ -1,6 +1,11 @@
 require 'test_helper'
 
 class Salesforce.connection::AsyncTest < ActiveSupport::TestCase
+  setup do
+    Salesforce::Config.instance.server_instance 'awesome-2000'
+    Salesforce::Config.instance.server_domain 'something.salesforce.com'
+  end
+
   def async_post(path, body, options = {})
     as_logged_in_user do
       convert_body RestClient.post(async_api_url(path), body, async_headers(options)), options
@@ -12,7 +17,7 @@ class Salesforce.connection::AsyncTest < ActiveSupport::TestCase
   def test_async_post__json
     Salesforce::Authentication.stubs(:session_id).returns('session_id')
     http_body = stub(:body => { :result => 'foo' }.to_json)
-    RestClient.expects(:post).with('https://.salesforce.com/services/async/22.0/path', :body, {'X-SFDC-Session' => 'session_id', :content_type => 'application/json'}).returns(http_body)
+    RestClient.expects(:post).with('https://awesome-2000.something.salesforce.com/services/async/22.0/path', :body, {'X-SFDC-Session' => 'session_id', :content_type => 'application/json'}).returns(http_body)
     assert_equal({'result' => 'foo'}, Salesforce.connection.async_post('path', :body, :format => :json))
   end
   
@@ -26,7 +31,7 @@ class Salesforce.connection::AsyncTest < ActiveSupport::TestCase
       assert false, "Shouldn't have gotten here"
     rescue => e
       assert_equal "Salesforce::InvalidRequest", e.class.name
-      assert_equal "MALFORMED_QUERY: someproblem while accessing https://.salesforce.com/services/async/22.0/path", e.message
+      assert_equal "MALFORMED_QUERY: someproblem while accessing https://awesome-2000.something.salesforce.com/services/async/22.0/path", e.message
     end
   end
   
@@ -34,14 +39,14 @@ class Salesforce.connection::AsyncTest < ActiveSupport::TestCase
     Salesforce::Authentication.stubs(:session_id).returns('session_id')
     error = RestClient::BadRequest.new
     error.stubs(:http_body).returns("<?xml version=\"1.0\" encoding=\"UTF-8\"?><Errors><Error><errorCode>MALFORMED_QUERY</errorCode><message>someproblem</message></Error></Errors>" )
-    RestClient.expects(:post).with('https://.salesforce.com/services/async/22.0/path', :body, {'X-SFDC-Session' => 'session_id', :content_type => 'application/xml'}).raises(error)
+    RestClient.expects(:post).with('https://awesome-2000.something.salesforce.com/services/async/22.0/path', :body, {'X-SFDC-Session' => 'session_id', :content_type => 'application/xml'}).raises(error)
     
     begin
       Salesforce.connection.async_post('path', :body, :format => :xml)
       assert false, "Shouldn't have gotten here"
     rescue => e
       assert_equal "Salesforce::InvalidRequest", e.class.name
-      assert_equal "MALFORMED_QUERY: someproblem while accessing https://.salesforce.com/services/async/22.0/path", e.message
+      assert_equal "MALFORMED_QUERY: someproblem while accessing https://awesome-2000.something.salesforce.com/services/async/22.0/path", e.message
     end
   end
   
@@ -49,13 +54,13 @@ class Salesforce.connection::AsyncTest < ActiveSupport::TestCase
     Salesforce::Authentication.stubs(:session_id).returns('session_id')
     error = RestClient::ResourceNotFound.new
     error.stubs(:http_body).returns("[{\"message\":\"someproblem\",\"errorCode\":\"MALFORMED_QUERY\"}]")
-    RestClient.expects(:post).with('https://.salesforce.com/services/async/22.0/path', :body, {'X-SFDC-Session' => 'session_id', :content_type => 'application/json'}).raises(error)
+    RestClient.expects(:post).with('https://awesome-2000.something.salesforce.com/services/async/22.0/path', :body, {'X-SFDC-Session' => 'session_id', :content_type => 'application/json'}).raises(error)
     begin
       Salesforce.connection.async_post('path', :body, :format => :json)
       assert false, "Shouldn't have gotten here"
     rescue => e
       assert_equal "Salesforce::InvalidRequest", e.class.name
-      assert_equal "MALFORMED_QUERY: someproblem while accessing https://.salesforce.com/services/async/22.0/path", e.message
+      assert_equal "MALFORMED_QUERY: someproblem while accessing https://awesome-2000.something.salesforce.com/services/async/22.0/path", e.message
     end
   end
   
@@ -63,28 +68,28 @@ class Salesforce.connection::AsyncTest < ActiveSupport::TestCase
     Salesforce::Authentication.stubs(:session_id).returns('session_id')
     error = RestClient::ResourceNotFound.new
     error.stubs(:http_body).returns("<?xml version=\"1.0\" encoding=\"UTF-8\"?><Errors><Error><errorCode>MALFORMED_QUERY</errorCode><message>someproblem</message></Error></Errors>" )
-    RestClient.expects(:post).with('https://.salesforce.com/services/async/22.0/path', :body, {'X-SFDC-Session' => 'session_id', :content_type => 'application/xml'}).raises(error)
+    RestClient.expects(:post).with('https://awesome-2000.something.salesforce.com/services/async/22.0/path', :body, {'X-SFDC-Session' => 'session_id', :content_type => 'application/xml'}).raises(error)
     
     begin
       Salesforce.connection.async_post('path', :body, :format => :xml)
       assert false, "Shouldn't have gotten here"
     rescue => e
       assert_equal "Salesforce::InvalidRequest", e.class.name
-      assert_equal "MALFORMED_QUERY: someproblem while accessing https://.salesforce.com/services/async/22.0/path", e.message
+      assert_equal "MALFORMED_QUERY: someproblem while accessing https://awesome-2000.something.salesforce.com/services/async/22.0/path", e.message
     end
   end
   
   def test_async_post__xml
     Salesforce::Authentication.stubs(:session_id).returns('session_id')
     http_body = stub(:body => { :result => 'foo' }.to_xml)
-    RestClient.expects(:post).with('https://.salesforce.com/services/async/22.0/path', :body, {'X-SFDC-Session' => 'session_id', :content_type => 'application/xml'}).returns(http_body)
+    RestClient.expects(:post).with('https://awesome-2000.something.salesforce.com/services/async/22.0/path', :body, {'X-SFDC-Session' => 'session_id', :content_type => 'application/xml'}).returns(http_body)
     assert_equal({'result' => 'foo'}, Salesforce.connection.async_post('path', :body, :format => :xml))
   end
   
   def test_async_get__json
     Salesforce::Authentication.stubs(:session_id).returns('session_id')
     http_body = stub(:body => { :result => 'foo' }.to_json)
-    RestClient.expects(:get).with('https://.salesforce.com/services/async/22.0/path', {'X-SFDC-Session' => 'session_id', :content_type => 'application/json'}).returns(http_body)
+    RestClient.expects(:get).with('https://awesome-2000.something.salesforce.com/services/async/22.0/path', {'X-SFDC-Session' => 'session_id', :content_type => 'application/json'}).returns(http_body)
     assert_equal({'result' => 'foo'}, Salesforce.connection.async_get('path', :format => :json))
   end
   
@@ -92,14 +97,14 @@ class Salesforce.connection::AsyncTest < ActiveSupport::TestCase
     Salesforce::Authentication.stubs(:session_id).returns('session_id')
     error = RestClient::BadRequest.new
     error.stubs(:http_body).returns("[{\"message\":\"someproblem\",\"errorCode\":\"MALFORMED_QUERY\"}]")
-    RestClient.expects(:get).with('https://.salesforce.com/services/async/22.0/path', {'X-SFDC-Session' => 'session_id', :content_type => 'application/json'}).raises(error)
+    RestClient.expects(:get).with('https://awesome-2000.something.salesforce.com/services/async/22.0/path', {'X-SFDC-Session' => 'session_id', :content_type => 'application/json'}).raises(error)
     
     begin
       Salesforce.connection.async_get('path', :format => :json)
       assert false, "Shouldn't have gotten here"
     rescue => e
       assert_equal "Salesforce::InvalidRequest", e.class.name
-      assert_equal "MALFORMED_QUERY: someproblem while accessing https://.salesforce.com/services/async/22.0/path", e.message
+      assert_equal "MALFORMED_QUERY: someproblem while accessing https://awesome-2000.something.salesforce.com/services/async/22.0/path", e.message
     end
   end
   
@@ -107,26 +112,26 @@ class Salesforce.connection::AsyncTest < ActiveSupport::TestCase
     Salesforce::Authentication.stubs(:session_id).returns('session_id')
     error = RestClient::BadRequest.new
     error.stubs(:http_body).returns("<?xml version=\"1.0\" encoding=\"UTF-8\"?><Errors><Error><errorCode>MALFORMED_QUERY</errorCode><message>someproblem</message></Error></Errors>" )
-    RestClient.expects(:get).with('https://.salesforce.com/services/async/22.0/path', {'X-SFDC-Session' => 'session_id', :content_type => 'application/xml'}).raises(error)
+    RestClient.expects(:get).with('https://awesome-2000.something.salesforce.com/services/async/22.0/path', {'X-SFDC-Session' => 'session_id', :content_type => 'application/xml'}).raises(error)
     
     begin
       Salesforce.connection.async_get('path', :format => :xml)
       assert false, "Shouldn't have gotten here"
     rescue => e
       assert_equal "Salesforce::InvalidRequest", e.class.name
-      assert_equal "MALFORMED_QUERY: someproblem while accessing https://.salesforce.com/services/async/22.0/path", e.message
+      assert_equal "MALFORMED_QUERY: someproblem while accessing https://awesome-2000.something.salesforce.com/services/async/22.0/path", e.message
     end
   end
   
   def test_async_get__xml
     Salesforce::Authentication.stubs(:session_id).returns('session_id')
     http_body = stub(:body => { :result => 'foo' }.to_xml)
-    RestClient.expects(:get).with('https://.salesforce.com/services/async/22.0/path', {'X-SFDC-Session' => 'session_id', :content_type => 'application/xml'}).returns(http_body)
+    RestClient.expects(:get).with('https://awesome-2000.something.salesforce.com/services/async/22.0/path', {'X-SFDC-Session' => 'session_id', :content_type => 'application/xml'}).returns(http_body)
     assert_equal({'result' => 'foo'}, Salesforce.connection.async_get('path', :format => :xml))
   end
   
   def test_async_api_url
-    assert_equal 'https://.salesforce.com/services/async/22.0/path', Salesforce.connection.async_api_url('path')
+    assert_equal 'https://awesome-2000.something.salesforce.com/services/async/22.0/path', Salesforce.connection.async_api_url('path')
   end
   
   

--- a/test/salesforce/connection/http_methods_test.rb
+++ b/test/salesforce/connection/http_methods_test.rb
@@ -1,6 +1,11 @@
 require 'test_helper'
 
 class Salesforce.connection::HttpMethodsTest < ActiveSupport::TestCase
+  setup do
+    Salesforce::Config.instance.server_instance 'awesome-2000'
+    Salesforce::Config.instance.server_domain 'something.salesforce.com'
+  end
+
   def test_content_type_headers
     assert_equal({ :content_type => 'application/json'}, Salesforce.connection.content_type_headers(:format => :json))
     assert_equal({ :content_type => 'application/json'}, Salesforce.connection.content_type_headers(:format => "json"))
@@ -13,7 +18,7 @@ class Salesforce.connection::HttpMethodsTest < ActiveSupport::TestCase
   def test_get__json
     Salesforce::Authentication.stubs(:session_id).returns('session_id')
     http_body = stub(:body => { :result => 'foo' }.to_json)
-    RestClient.expects(:get).with('https://.salesforce.com/services/data/v22.0/path', {'Authorization' => 'OAuth session_id', :content_type => 'application/json'}).returns(http_body)
+    RestClient.expects(:get).with('https://awesome-2000.something.salesforce.com/services/data/v22.0/path', {'Authorization' => 'OAuth session_id', :content_type => 'application/json'}).returns(http_body)
     assert_equal({'result' => 'foo'}, Salesforce.connection.get('path', :format => :json))
   end
   
@@ -21,14 +26,14 @@ class Salesforce.connection::HttpMethodsTest < ActiveSupport::TestCase
     Salesforce::Authentication.stubs(:session_id).returns('session_id')
     error = RestClient::BadRequest.new
     error.stubs(:http_body).returns("[{\"message\":\"someproblem\",\"errorCode\":\"MALFORMED_QUERY\"}]")
-    RestClient.expects(:get).with('https://.salesforce.com/services/data/v22.0/path', {'Authorization' => 'OAuth session_id', :content_type => 'application/json'}).raises(error)
+    RestClient.expects(:get).with('https://awesome-2000.something.salesforce.com/services/data/v22.0/path', {'Authorization' => 'OAuth session_id', :content_type => 'application/json'}).raises(error)
     
     begin
       Salesforce.connection.get('path', :format => :json)
       assert false, "Shouldn't have gotten here"
     rescue => e
       assert_equal "Salesforce::InvalidRequest", e.class.name
-      assert_equal "MALFORMED_QUERY: someproblem while accessing https://.salesforce.com/services/data/v22.0/path", e.message
+      assert_equal "MALFORMED_QUERY: someproblem while accessing https://awesome-2000.something.salesforce.com/services/data/v22.0/path", e.message
     end
   end
   
@@ -36,28 +41,28 @@ class Salesforce.connection::HttpMethodsTest < ActiveSupport::TestCase
     Salesforce::Authentication.stubs(:session_id).returns('session_id')
     error = RestClient::BadRequest.new
     error.stubs(:http_body).returns("<?xml version=\"1.0\" encoding=\"UTF-8\"?><Errors><Error><errorCode>MALFORMED_QUERY</errorCode><message>someproblem</message></Error></Errors>" )
-    RestClient.expects(:get).with('https://.salesforce.com/services/data/v22.0/path', {'Authorization' => 'OAuth session_id', :content_type => 'application/xml'}).raises(error)
+    RestClient.expects(:get).with('https://awesome-2000.something.salesforce.com/services/data/v22.0/path', {'Authorization' => 'OAuth session_id', :content_type => 'application/xml'}).raises(error)
     
     begin
       Salesforce.connection.get('path', :format => :xml)
       assert false, "Shouldn't have gotten here"
     rescue => e
       assert_equal "Salesforce::InvalidRequest", e.class.name
-      assert_equal "MALFORMED_QUERY: someproblem while accessing https://.salesforce.com/services/data/v22.0/path", e.message
+      assert_equal "MALFORMED_QUERY: someproblem while accessing https://awesome-2000.something.salesforce.com/services/data/v22.0/path", e.message
     end
   end
   
   def test_get__xml
     Salesforce::Authentication.stubs(:session_id).returns('session_id')
     http_body = stub(:body => { :result => 'foo' }.to_xml)
-    RestClient.expects(:get).with('https://.salesforce.com/services/data/v22.0/path', {'Authorization' => 'OAuth session_id', :content_type => 'application/xml'}).returns(http_body)
+    RestClient.expects(:get).with('https://awesome-2000.something.salesforce.com/services/data/v22.0/path', {'Authorization' => 'OAuth session_id', :content_type => 'application/xml'}).returns(http_body)
     assert_equal({'result' => 'foo'}, Salesforce.connection.get('path', :format => :xml))
   end
   
   def test_patch__json
     Salesforce::Authentication.stubs(:session_id).returns('session_id')
     http_body = stub(:code => 204, :body => '')
-    RestClient.expects(:patch).with('https://.salesforce.com/services/data/v22.0/path', :body, {'Authorization' => 'OAuth session_id', :content_type => 'application/json'}).returns(http_body)
+    RestClient.expects(:patch).with('https://awesome-2000.something.salesforce.com/services/data/v22.0/path', :body, {'Authorization' => 'OAuth session_id', :content_type => 'application/json'}).returns(http_body)
     assert Salesforce.connection.patch('path', :body, :format => :json)
   end
   
@@ -65,13 +70,13 @@ class Salesforce.connection::HttpMethodsTest < ActiveSupport::TestCase
     Salesforce::Authentication.stubs(:session_id).returns('session_id')
     error = RestClient::BadRequest.new
     error.stubs(:http_body).returns("[{\"message\":\"someproblem\",\"errorCode\":\"MALFORMED_QUERY\"}]")
-    RestClient.expects(:patch).with('https://.salesforce.com/services/data/v22.0/path', :body, {'Authorization' => 'OAuth session_id', :content_type => 'application/json'}).raises(error)
+    RestClient.expects(:patch).with('https://awesome-2000.something.salesforce.com/services/data/v22.0/path', :body, {'Authorization' => 'OAuth session_id', :content_type => 'application/json'}).raises(error)
     begin
       Salesforce.connection.patch('path', :body, :format => :json)
       assert false, "Shouldn't have gotten here"
     rescue => e
       assert_equal "Salesforce::InvalidRequest", e.class.name
-      assert_equal "MALFORMED_QUERY: someproblem while accessing https://.salesforce.com/services/data/v22.0/path", e.message
+      assert_equal "MALFORMED_QUERY: someproblem while accessing https://awesome-2000.something.salesforce.com/services/data/v22.0/path", e.message
     end
   end
   
@@ -79,14 +84,14 @@ class Salesforce.connection::HttpMethodsTest < ActiveSupport::TestCase
     Salesforce::Authentication.stubs(:session_id).returns('session_id')
     error = RestClient::BadRequest.new
     error.stubs(:http_body).returns("<?xml version=\"1.0\" encoding=\"UTF-8\"?><Errors><Error><errorCode>MALFORMED_QUERY</errorCode><message>someproblem</message></Error></Errors>" )
-    RestClient.expects(:patch).with('https://.salesforce.com/services/data/v22.0/path', :body, {'Authorization' => 'OAuth session_id', :content_type => 'application/xml'}).raises(error)
+    RestClient.expects(:patch).with('https://awesome-2000.something.salesforce.com/services/data/v22.0/path', :body, {'Authorization' => 'OAuth session_id', :content_type => 'application/xml'}).raises(error)
     
     begin
       Salesforce.connection.patch('path', :body, :format => :xml)
       assert false, "Shouldn't have gotten here"
     rescue => e
       assert_equal "Salesforce::InvalidRequest", e.class.name
-      assert_equal "MALFORMED_QUERY: someproblem while accessing https://.salesforce.com/services/data/v22.0/path", e.message
+      assert_equal "MALFORMED_QUERY: someproblem while accessing https://awesome-2000.something.salesforce.com/services/data/v22.0/path", e.message
     end
   end
   
@@ -94,13 +99,13 @@ class Salesforce.connection::HttpMethodsTest < ActiveSupport::TestCase
     Salesforce::Authentication.stubs(:session_id).returns('session_id')
     error = RestClient::ResourceNotFound.new
     error.stubs(:http_body).returns("[{\"message\":\"someproblem\",\"errorCode\":\"MALFORMED_QUERY\"}]")
-    RestClient.expects(:patch).with('https://.salesforce.com/services/data/v22.0/path', :body, {'Authorization' => 'OAuth session_id', :content_type => 'application/json'}).raises(error)
+    RestClient.expects(:patch).with('https://awesome-2000.something.salesforce.com/services/data/v22.0/path', :body, {'Authorization' => 'OAuth session_id', :content_type => 'application/json'}).raises(error)
     begin
       Salesforce.connection.patch('path', :body, :format => :json)
       assert false, "Shouldn't have gotten here"
     rescue => e
       assert_equal "Salesforce::InvalidRequest", e.class.name
-      assert_equal "MALFORMED_QUERY: someproblem while accessing https://.salesforce.com/services/data/v22.0/path", e.message
+      assert_equal "MALFORMED_QUERY: someproblem while accessing https://awesome-2000.something.salesforce.com/services/data/v22.0/path", e.message
     end
   end
   
@@ -108,21 +113,21 @@ class Salesforce.connection::HttpMethodsTest < ActiveSupport::TestCase
     Salesforce::Authentication.stubs(:session_id).returns('session_id')
     error = RestClient::ResourceNotFound.new
     error.stubs(:http_body).returns("<?xml version=\"1.0\" encoding=\"UTF-8\"?><Errors><Error><errorCode>MALFORMED_QUERY</errorCode><message>someproblem</message></Error></Errors>" )
-    RestClient.expects(:patch).with('https://.salesforce.com/services/data/v22.0/path', :body, {'Authorization' => 'OAuth session_id', :content_type => 'application/xml'}).raises(error)
+    RestClient.expects(:patch).with('https://awesome-2000.something.salesforce.com/services/data/v22.0/path', :body, {'Authorization' => 'OAuth session_id', :content_type => 'application/xml'}).raises(error)
     
     begin
       Salesforce.connection.patch('path', :body, :format => :xml)
       assert false, "Shouldn't have gotten here"
     rescue => e
       assert_equal "Salesforce::InvalidRequest", e.class.name
-      assert_equal "MALFORMED_QUERY: someproblem while accessing https://.salesforce.com/services/data/v22.0/path", e.message
+      assert_equal "MALFORMED_QUERY: someproblem while accessing https://awesome-2000.something.salesforce.com/services/data/v22.0/path", e.message
     end
   end
   
   def test_patch__xml
     Salesforce::Authentication.stubs(:session_id).returns('session_id')
     http_body = stub(:code => 204, :body => '')
-    RestClient.expects(:patch).with('https://.salesforce.com/services/data/v22.0/path', :body, {'Authorization' => 'OAuth session_id', :content_type => 'application/xml'}).returns(http_body)
+    RestClient.expects(:patch).with('https://awesome-2000.something.salesforce.com/services/data/v22.0/path', :body, {'Authorization' => 'OAuth session_id', :content_type => 'application/xml'}).returns(http_body)
     assert Salesforce.connection.patch('path', :body, :format => :xml)
   end
   
@@ -130,7 +135,7 @@ class Salesforce.connection::HttpMethodsTest < ActiveSupport::TestCase
   def test_post__json
     Salesforce::Authentication.stubs(:session_id).returns('session_id')
     http_body = stub(:body => { :result => 'foo' }.to_json)
-    RestClient.expects(:post).with('https://.salesforce.com/services/data/v22.0/path', :body, {'Authorization' => 'OAuth session_id', :content_type => 'application/json'}).returns(http_body)
+    RestClient.expects(:post).with('https://awesome-2000.something.salesforce.com/services/data/v22.0/path', :body, {'Authorization' => 'OAuth session_id', :content_type => 'application/json'}).returns(http_body)
     assert_equal({'result' => 'foo'}, Salesforce.connection.post('path', :body, :format => :json))
   end
   
@@ -138,13 +143,13 @@ class Salesforce.connection::HttpMethodsTest < ActiveSupport::TestCase
     Salesforce::Authentication.stubs(:session_id).returns('session_id')
     error = RestClient::BadRequest.new
     error.stubs(:http_body).returns("[{\"message\":\"someproblem\",\"errorCode\":\"MALFORMED_QUERY\"}]")
-    RestClient.expects(:post).with('https://.salesforce.com/services/data/v22.0/path', :body, {'Authorization' => 'OAuth session_id', :content_type => 'application/json'}).raises(error)
+    RestClient.expects(:post).with('https://awesome-2000.something.salesforce.com/services/data/v22.0/path', :body, {'Authorization' => 'OAuth session_id', :content_type => 'application/json'}).raises(error)
     begin
       Salesforce.connection.post('path', :body, :format => :json)
       assert false, "Shouldn't have gotten here"
     rescue => e
       assert_equal "Salesforce::InvalidRequest", e.class.name
-      assert_equal "MALFORMED_QUERY: someproblem while accessing https://.salesforce.com/services/data/v22.0/path", e.message
+      assert_equal "MALFORMED_QUERY: someproblem while accessing https://awesome-2000.something.salesforce.com/services/data/v22.0/path", e.message
     end
   end
   
@@ -152,14 +157,14 @@ class Salesforce.connection::HttpMethodsTest < ActiveSupport::TestCase
     Salesforce::Authentication.stubs(:session_id).returns('session_id')
     error = RestClient::BadRequest.new
     error.stubs(:http_body).returns("<?xml version=\"1.0\" encoding=\"UTF-8\"?><Errors><Error><errorCode>MALFORMED_QUERY</errorCode><message>someproblem</message></Error></Errors>" )
-    RestClient.expects(:post).with('https://.salesforce.com/services/data/v22.0/path', :body, {'Authorization' => 'OAuth session_id', :content_type => 'application/xml'}).raises(error)
+    RestClient.expects(:post).with('https://awesome-2000.something.salesforce.com/services/data/v22.0/path', :body, {'Authorization' => 'OAuth session_id', :content_type => 'application/xml'}).raises(error)
     
     begin
       Salesforce.connection.post('path', :body, :format => :xml)
       assert false, "Shouldn't have gotten here"
     rescue => e
       assert_equal "Salesforce::InvalidRequest", e.class.name
-      assert_equal "MALFORMED_QUERY: someproblem while accessing https://.salesforce.com/services/data/v22.0/path", e.message
+      assert_equal "MALFORMED_QUERY: someproblem while accessing https://awesome-2000.something.salesforce.com/services/data/v22.0/path", e.message
     end
   end
   
@@ -167,13 +172,13 @@ class Salesforce.connection::HttpMethodsTest < ActiveSupport::TestCase
     Salesforce::Authentication.stubs(:session_id).returns('session_id')
     error = RestClient::ResourceNotFound.new
     error.stubs(:http_body).returns("[{\"message\":\"someproblem\",\"errorCode\":\"MALFORMED_QUERY\"}]")
-    RestClient.expects(:post).with('https://.salesforce.com/services/data/v22.0/path', :body, {'Authorization' => 'OAuth session_id', :content_type => 'application/json'}).raises(error)
+    RestClient.expects(:post).with('https://awesome-2000.something.salesforce.com/services/data/v22.0/path', :body, {'Authorization' => 'OAuth session_id', :content_type => 'application/json'}).raises(error)
     begin
       Salesforce.connection.post('path', :body, :format => :json)
       assert false, "Shouldn't have gotten here"
     rescue => e
       assert_equal "Salesforce::InvalidRequest", e.class.name
-      assert_equal "MALFORMED_QUERY: someproblem while accessing https://.salesforce.com/services/data/v22.0/path", e.message
+      assert_equal "MALFORMED_QUERY: someproblem while accessing https://awesome-2000.something.salesforce.com/services/data/v22.0/path", e.message
     end
   end
   
@@ -181,21 +186,21 @@ class Salesforce.connection::HttpMethodsTest < ActiveSupport::TestCase
     Salesforce::Authentication.stubs(:session_id).returns('session_id')
     error = RestClient::ResourceNotFound.new
     error.stubs(:http_body).returns("<?xml version=\"1.0\" encoding=\"UTF-8\"?><Errors><Error><errorCode>MALFORMED_QUERY</errorCode><message>someproblem</message></Error></Errors>" )
-    RestClient.expects(:post).with('https://.salesforce.com/services/data/v22.0/path', :body, {'Authorization' => 'OAuth session_id', :content_type => 'application/xml'}).raises(error)
+    RestClient.expects(:post).with('https://awesome-2000.something.salesforce.com/services/data/v22.0/path', :body, {'Authorization' => 'OAuth session_id', :content_type => 'application/xml'}).raises(error)
     
     begin
       Salesforce.connection.post('path', :body, :format => :xml)
       assert false, "Shouldn't have gotten here"
     rescue => e
       assert_equal "Salesforce::InvalidRequest", e.class.name
-      assert_equal "MALFORMED_QUERY: someproblem while accessing https://.salesforce.com/services/data/v22.0/path", e.message
+      assert_equal "MALFORMED_QUERY: someproblem while accessing https://awesome-2000.something.salesforce.com/services/data/v22.0/path", e.message
     end
   end
   
   def test_post__xml
     Salesforce::Authentication.stubs(:session_id).returns('session_id')
     http_body = stub(:body => { :result => 'foo' }.to_xml)
-    RestClient.expects(:post).with('https://.salesforce.com/services/data/v22.0/path', :body, {'Authorization' => 'OAuth session_id', :content_type => 'application/xml'}).returns(http_body)
+    RestClient.expects(:post).with('https://awesome-2000.something.salesforce.com/services/data/v22.0/path', :body, {'Authorization' => 'OAuth session_id', :content_type => 'application/xml'}).returns(http_body)
     assert_equal({'result' => 'foo'}, Salesforce.connection.post('path', :body, :format => :xml))
   end
   
@@ -203,14 +208,14 @@ class Salesforce.connection::HttpMethodsTest < ActiveSupport::TestCase
     Salesforce::Authentication.stubs(:session_id).returns('session_id')
     error = RestClient::BadRequest.new
     error.stubs(:http_body).returns("<?xml version=\"1.0\" encoding=\"UTF-8\"?><Errors><Error><errorCode>MALFORMED_QUERY</errorCode><message>someproblem</message></Error></Errors>" )
-    RestClient.expects(:delete).with('https://.salesforce.com/services/data/v22.0/path', {'Authorization' => 'OAuth session_id', :content_type => 'application/xml'}).raises(error)
+    RestClient.expects(:delete).with('https://awesome-2000.something.salesforce.com/services/data/v22.0/path', {'Authorization' => 'OAuth session_id', :content_type => 'application/xml'}).raises(error)
     
     begin
       Salesforce.connection.delete('path')
       assert false, "Shouldn't have gotten here"
     rescue => e
       assert_equal "Salesforce::InvalidRequest", e.class.name
-      assert_equal "MALFORMED_QUERY: someproblem while accessing https://.salesforce.com/services/data/v22.0/path", e.message
+      assert_equal "MALFORMED_QUERY: someproblem while accessing https://awesome-2000.something.salesforce.com/services/data/v22.0/path", e.message
     end
   end
   
@@ -218,25 +223,25 @@ class Salesforce.connection::HttpMethodsTest < ActiveSupport::TestCase
     Salesforce::Authentication.stubs(:session_id).returns('session_id')
     error = RestClient::ResourceNotFound.new
     error.stubs(:http_body).returns("<?xml version=\"1.0\" encoding=\"UTF-8\"?><Errors><Error><errorCode>MALFORMED_QUERY</errorCode><message>someproblem</message></Error></Errors>" )
-    RestClient.expects(:delete).with('https://.salesforce.com/services/data/v22.0/path', {'Authorization' => 'OAuth session_id', :content_type => 'application/xml'}).raises(error)
+    RestClient.expects(:delete).with('https://awesome-2000.something.salesforce.com/services/data/v22.0/path', {'Authorization' => 'OAuth session_id', :content_type => 'application/xml'}).raises(error)
     
     begin
       Salesforce.connection.delete('path')
       assert false, "Shouldn't have gotten here"
     rescue => e
       assert_equal "Salesforce::InvalidRequest", e.class.name
-      assert_equal "MALFORMED_QUERY: someproblem while accessing https://.salesforce.com/services/data/v22.0/path", e.message
+      assert_equal "MALFORMED_QUERY: someproblem while accessing https://awesome-2000.something.salesforce.com/services/data/v22.0/path", e.message
     end
   end
   
   def test_delete__xml
     Salesforce::Authentication.stubs(:session_id).returns('session_id')
-    RestClient.expects(:delete).with('https://.salesforce.com/services/data/v22.0/path', {'Authorization' => 'OAuth session_id', :content_type => 'application/xml'}).returns(stub(:body => ''))
+    RestClient.expects(:delete).with('https://awesome-2000.something.salesforce.com/services/data/v22.0/path', {'Authorization' => 'OAuth session_id', :content_type => 'application/xml'}).returns(stub(:body => ''))
     assert Salesforce.connection.delete('path')
   end
   
   def test_salesforce_url
-    assert_equal 'https://.salesforce.com/services/data/v22.0/path', Salesforce.connection.salesforce_url("path")
-    assert_equal 'https://.salesforce.com/services/data/23.0/foo', Salesforce.connection.salesforce_url("/services/data/23.0/foo")
+    assert_equal 'https://awesome-2000.something.salesforce.com/services/data/v22.0/path', Salesforce.connection.salesforce_url("path")
+    assert_equal 'https://awesome-2000.something.salesforce.com/services/data/23.0/foo', Salesforce.connection.salesforce_url("/services/data/23.0/foo")
   end  
 end


### PR DESCRIPTION
With My Domain, the notion of a salesforce 'instance' doesn't quite make sense anymore. This now uses the salesforce domain directly instead of assuming the format it's in

https://www.pivotaltracker.com/story/show/153618694

This PR contains the same changes as #12 but is to be merged to master rather than the 1.x branch