### PR TITLE
Fix sandbox urls for MyDomain [#153618694]

### DIFF
--- a/lib/salesforce/authentication.rb
+++ b/lib/salesforce/authentication.rb
@@ -14,7 +14,7 @@ module Salesforce
       Config.instance.session_id        result[:session_id]
 
       host = URI.parse(result[:server_url]).host
-      host_match = host.match(/(?<instance>[a-z0-9\-]+)\.(?<domain>(?:my\.)?salesforce\.com)/)
+      host_match = host.match(/(?<instance>[a-z0-9\-]+(?:\.[a-z]+\d+)?)\.(?<domain>(?:my\.)?salesforce\.com)/)
 
       Config.instance.server_instance   host_match[:instance]
       Config.instance.server_domain     host_match[:domain]

--- a/test/salesforce/authentication_test.rb
+++ b/test/salesforce/authentication_test.rb
@@ -66,5 +66,22 @@ class Salesforce::AuthenticationTest < ActiveSupport::TestCase
     assert_equal "my.salesforce.com", Salesforce::Config.server_domain
     assert_equal "user_id", Salesforce::Config.user_id
   end
+
+  def test_generate_new_session_id__calls_connection_login__my_domain__sandbox
+    result = {
+      :session_id => "session_id",
+      :server_url => "https://awesome-2000--some-sandbox.na2001.my.salesforce.com/services/Soap/c/22.0/00DQ00000001LRX",
+      :user_id    => "user_id"
+    }
+
+    Salesforce.connection.expects(:login).returns(result)
+
+    assert_equal "session_id", Salesforce::Authentication.generate_new_session_id
+    assert_equal "https://awesome-2000--some-sandbox.na2001.my.salesforce.com/services/Soap/c/22.0/00DQ00000001LRX", Salesforce::Config.soap_endpoint_url
+    assert_equal "session_id", Salesforce::Config.session_id
+    assert_equal "awesome-2000--some-sandbox.na2001", Salesforce::Config.server_instance
+    assert_equal "my.salesforce.com", Salesforce::Config.server_domain
+    assert_equal "user_id", Salesforce::Config.user_id
+  end
   
 end


### PR DESCRIPTION
Sandbox urls take the form `https://<subdomain>--<sandboxname>.<instance>.my.salesforce.com` , where instance is the usual csXX, naXX, etc

https://www.pivotaltracker.com/story/show/153618694